### PR TITLE
Add alias support

### DIFF
--- a/example/example-usage.js
+++ b/example/example-usage.js
@@ -16,11 +16,14 @@ co(function * () {
     ],
     /** Endpoint handlers */
     endpoints: {
-      '/api/foo': {
+      '/api/foo/:id': { // Pass object to handle each HTTP verbs
         'POST': (ctx) => {
-          ctx.body = 'This is foo'
+          let { id } = ctx.params
+          ctx.body = `This is foo with id: "${id}"`
         }
-      }
+      },
+      '/api': '/api/index', // Pass string to create alias
+      '/api/index': () => { /* ... */ } // Pass function to handle all HTTP verbs
     }
   })
 

--- a/lib/middlewares/route_middleware.js
+++ b/lib/middlewares/route_middleware.js
@@ -13,16 +13,25 @@ function routeMiddleware (routes) {
   let router = new KoaRouter()
   for (let pathname of Object.keys(routes)) {
     for (let route of [].concat(routes[ pathname ])) {
-      if (typeof route === 'function') {
-        router.all(pathname, route)
-      } else {
-        let methods = Object.keys(route).filter((method) => !method.match(/^[\$_]/))
-        for (let method of methods) {
-          let name = String(method).toLowerCase()
-          if (!router[ name ]) {
-            throw new Error(`Unknown method: ${method}`)
+      switch (typeof route) {
+        case 'function': {
+          router.all(pathname, route)
+          break
+        }
+        case 'string': {
+          router.redirect(pathname, route)
+          break
+        }
+        default: {
+          let methods = Object.keys(route).filter((method) => !method.match(/^[\$_]/))
+          for (let method of methods) {
+            let name = String(method).toLowerCase()
+            if (!router[ name ]) {
+              throw new Error(`Unknown method: ${method}`)
+            }
+            router[ name ](pathname, route[ method ])
           }
-          router[ name ](pathname, route[ method ])
+          break
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sg-server",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "HTTP server for SUGOS",
   "main": "lib",
   "scripts": {
@@ -33,7 +33,7 @@
     "koa-static": "^3.0.0"
   },
   "devDependencies": {
-    "amocha": "*",
+    "amocha": "^2.0.0",
     "ape-doc": "^2.0.4",
     "ape-formatting": "^1.0.1",
     "ape-releasing": "^4.0.1",


### PR DESCRIPTION
Endpointにstringを渡すとredirectするようにした

```javascript
endpoints: {
  '/api': '/api/index', // Pass string to create alias
  '/api/index': () => { /* ... */ } // Pass function to handle all HTTP verbs
}
```